### PR TITLE
Added `export MACOSX_DEPLOYMENT_TARGET=14.0`** - This sets the

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,10 +94,9 @@ jobs:
       - name: Build release binary (x86_64 macOS)
         if: matrix.target == 'x86_64-apple-darwin'
         run: |
-          # Build with x86_64 target but don't pollute host (arm64) build environment
-          # LIBRARY_PATH/CPATH are only for the target linker, not for build scripts
+          export MACOSX_DEPLOYMENT_TARGET=14.0
           CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=clang \
-          CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS="-C link-arg=-arch -C link-arg=x86_64 -C link-arg=-L/usr/local/opt/zstd/lib -C link-arg=-lzstd -C link-arg=-L/usr/local/opt/llvm@18/lib" \
+          CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS="-C link-arg=-arch -C link-arg=x86_64 -C link-arg=-L/usr/local/opt/zstd/lib -C link-arg=-lzstd -C link-arg=-L/usr/local/opt/llvm@18/lib -C link-arg=-mmacosx-version-min=14.0" \
           cargo build --release --target ${{ matrix.target }}
 
       - name: Build release binary


### PR DESCRIPTION
environment variable that tells the toolchain to target macOS 14.0, matching the version LLVM was built for.

2. **Added `-C link-arg=-mmacosx-version-min=14.0`** - This explicitly tells the linker to use macOS 14.0 as the minimum version, preventing the mismatch with the 10.12 default.