### PR TITLE
Fix dyld libzstd error in distributed macOS binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,20 @@ env:
 
 jobs:
   test:
-    name: Test (${{ matrix.os }})
+    name: Test (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     # Limit job execution time to prevent resource abuse
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+          - target: aarch64-apple-darwin
+            os: macos-latest
 
     steps:
       - name: Checkout repository
@@ -53,7 +59,7 @@ jobs:
           wget -qO- https://apt.llvm.org/llvm.sh -O llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 18
-          sudo apt-get install -y libpolly-18-dev
+          sudo apt-get install -y libzstd-dev libpolly-18-dev
           echo "LLVM_SYS_180_PREFIX=/usr/lib/llvm-18" >> $GITHUB_ENV
 
       - name: Install LLVM 18 (macOS)
@@ -69,9 +75,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ matrix.os }}-${{ matrix.target }}-cargo-
 
       - name: Build
         run: cargo build --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            artifact_name: oitec
+            asset_name: oitec-x86_64-apple-darwin
+
           - target: aarch64-apple-darwin
             os: macos-latest
+            artifact_name: oitec
+            asset_name: oitec-aarch64-apple-darwin
+
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact_name: oitec
+            asset_name: oitec-x86_64-unknown-linux-gnu
+
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+            artifact_name: oitec
+            asset_name: oitec-aarch64-unknown-linux-gnu
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,30 +122,37 @@ jobs:
           # Remove arm64 zstd to prevent linker from finding it
           sudo rm -rf /opt/homebrew/opt/zstd
 
-          # Remove dynamic zstd libs from x86_64 install so the linker uses the static archive,
-          # preventing a runtime dependency on libzstd.1.dylib
-          rm -f /usr/local/opt/zstd/lib/libzstd*.dylib
+          # Copy only the static zstd archive to an isolated directory.
+          # The linker will find libzstd.a here (no .dylib), producing a
+          # self-contained binary without a runtime dependency on libzstd.1.dylib.
+          # We cannot remove the original .dylib because llvm-config needs it.
+          mkdir -p /tmp/zstd-static
+          cp /usr/local/opt/zstd/lib/libzstd.a /tmp/zstd-static/
 
           export MACOSX_DEPLOYMENT_TARGET=14.0
 
           # Use x86_64 clang wrapper so the linker runs as x86_64 and picks up x86_64 libs
           export CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=/usr/local/bin/clang-x86_64
 
-          # Ensure the linker sees the x86_64 zstd and llvm libs
-          export LIBRARY_PATH="/usr/local/opt/zstd/lib:/usr/local/opt/llvm@18/lib"
-          export CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS="-C link-arg=-arch -C link-arg=x86_64 -C link-arg=-L/usr/local/opt/zstd/lib -C link-arg=-L/usr/local/opt/llvm@18/lib -C link-arg=-mmacosx-version-min=14.0"
+          # Point to static-only dir first so linker prefers libzstd.a over the .dylib
+          export LIBRARY_PATH="/tmp/zstd-static:/usr/local/opt/llvm@18/lib"
+          export CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS="-C link-arg=-arch -C link-arg=x86_64 -C link-arg=-L/tmp/zstd-static -C link-arg=-L/usr/local/opt/llvm@18/lib -C link-arg=-mmacosx-version-min=14.0"
 
           cargo build --release --target ${{ matrix.target }}
 
       - name: Build release binary (aarch64 macOS)
         if: matrix.target == 'aarch64-apple-darwin'
         run: |
-          # Remove dynamic zstd libs so the linker uses the static archive,
-          # preventing a runtime dependency on /opt/homebrew/opt/zstd/lib/libzstd.1.dylib
-          rm -f /opt/homebrew/opt/zstd/lib/libzstd*.dylib
+          # Copy only the static zstd archive to an isolated directory.
+          # The linker will find libzstd.a here (no .dylib), producing a
+          # self-contained binary without a runtime dependency on libzstd.1.dylib.
+          # We cannot remove the original .dylib because llvm-config needs it.
+          mkdir -p /tmp/zstd-static
+          cp /opt/homebrew/opt/zstd/lib/libzstd.a /tmp/zstd-static/
 
           export MACOSX_DEPLOYMENT_TARGET=14.0
-          export LIBRARY_PATH="/opt/homebrew/opt/zstd/lib:/opt/homebrew/opt/llvm@18/lib"
+          export LIBRARY_PATH="/tmp/zstd-static:/opt/homebrew/opt/llvm@18/lib"
+          export CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS="-L /tmp/zstd-static"
 
           cargo build --release --target ${{ matrix.target }}
 
@@ -160,6 +167,16 @@ jobs:
       - name: Strip binary (Linux)
         if: runner.os == 'Linux'
         run: strip target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
+
+      - name: Verify no dynamic zstd dependency (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          if otool -L target/${{ matrix.target }}/release/${{ matrix.artifact_name }} | grep -q libzstd; then
+            echo "ERROR: binary still dynamically links to libzstd" >&2
+            otool -L target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
+            exit 1
+          fi
+          echo "OK: no dynamic zstd dependency"
 
       - name: Strip binary (macOS)
         if: runner.os == 'macOS'


### PR DESCRIPTION
- Fix #103 

## Summary
- Users installing `oitec` on macOS without Homebrew's zstd hit a `dyld: Library not loaded: libzstd.1.dylib` error at runtime
- Root cause: release builds dynamically linked against Homebrew's `libzstd.1.dylib`, creating a runtime dependency not present on end-user machines
- Fix: copy only `libzstd.a` to an isolated directory (`/tmp/zstd-static`) and point the linker there first, so it picks the static archive without breaking `llvm-config` (which itself needs the dylib)

## Changes
- **release.yml**: Both macOS targets now isolate `libzstd.a` in `/tmp/zstd-static/` and use it as the primary linker search path. Added `otool -L` post-build verification that fails if the binary still references libzstd dynamically.
- **ci.yml**: Switched from `os: [ubuntu-latest, macos-latest]` to a target-based matrix matching release.yml (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `aarch64-apple-darwin`). Added missing `libzstd-dev` to Linux CI.

## Test plan
- [ ] CI passes on all three targets (x86_64-linux, aarch64-linux, aarch64-macos)
- [ ] On a release build, `otool -L` verification step confirms no dynamic zstd reference
- [ ] Install the built binary on a machine without Homebrew zstd — no dyld error

🤖 Generated with [Claude Code](https://claude.com/claude-code)